### PR TITLE
fix the url of the link to the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository can be used to deploy a production instance of SilverStrike.
 
-Instructions on how to do that can be found [here](https://silverstrike.tk/setup/).
+Instructions on how to do that can be found [here](https://silverstrike.org/setup/).


### PR DESCRIPTION
I was busy trying setting up my local silverstrike and found this old link to the setup instructions.